### PR TITLE
Allow group to be specified as a variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 ## general
 spamassassin_user: spamd
+spamassassin_group: spamd
 spamassassin_home_dir: /var/log/spamassassin/
 
 # Write spamassassin config files (only install spamassassin and configure

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
       name: "{{ spamassassin_user }}"
       shell: /bin/false
       home: "{{ spamassassin_home_dir }}"
-      groups: spamd
+      groups: "{{ spamassassin_group }}"
       append: yes
   
   - name: ensure spamassassin's directories are present


### PR DESCRIPTION
Allow group to be specified as a variable.

Im on debian and both user and group is called debian-spamd.