### PR TITLE
Allow rerun of playbook + spamd-user need to have a valid shell

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,9 @@
 ## general
 spamassassin_user: spamd
 spamassassin_group: spamd
-spamassassin_home_dir: /var/log/spamassassin/
+spamassassin_home_dir: /var/lib/spamassassin/
+spamassassin_log_dir: /var/log/
+spamassassin_log_file: spamd.log
 
 # Write spamassassin config files (only install spamassassin and configure
 # cronjob if set to False)

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -16,3 +16,4 @@ lint: yamllint .
 provisioner:
   name: ansible
   become: true
+  log: True

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,5 +15,7 @@ platforms:
 lint: yamllint .
 provisioner:
   name: ansible
+  options:
+    vvv: True
   become: true
   log: True

--- a/molecule/docker/molecule.yml
+++ b/molecule/docker/molecule.yml
@@ -12,5 +12,8 @@ platforms:
 lint: yamllint .
 provisioner:
   name: ansible
+  log: True
+  options:
+    vvv: True
   playbooks:
     converge: ../default/converge.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
 - name: ensure spamd user is present
   user:
     name: "{{ spamassassin_user }}"
-    # Need to have a shell,otherwise updates in Debian fails
+    # Need to have a shell, otherwise updates in Debian fails
     shell: /bin/sh
     home: "{{ spamassassin_home_dir }}"
     groups: "{{ spamassassin_group }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,23 +1,46 @@
 ---
 
+- name: check if spamd user exist
+  shell: "id -u {{ spamassassin_user }}"
+  register: id_cmd
+  # rc=1 is OK, indicates that there is no spamd user
+  failed_when: id_cmd.rc >= 2
+
+- name: stop spamassassin
+  service:
+    name: spamassassin
+    state: stopped
+  failed_when: false  
+  when: id_cmd.rc == 0
+
+- name: Kill running processes for user spamd
+  shell: "killall -u {{ spamassassin_user }}"
+  register: killall_cmd
+  # rc=1 is OK, indicates that there are no processes to be killed
+  failed_when: killall_cmd.rc >= 2
+  when: id_cmd.rc == 0
+
+- name: ensure spamd group is present
+  group:
+    name: "{{ spamassassin_user }}"
+    state: present
+
+- name: ensure spamd user is present
+  user:
+    name: "{{ spamassassin_user }}"
+    # Need to have a shell, otherwise updates in Debian fails
+    shell: /bin/sh
+    home: "{{ spamassassin_home_dir }}"
+    groups: "{{ spamassassin_group }}"
+    append: yes
+
 - name: ensure spamassassin is installed
   apt:
     pkg: "{{ spamassassin_packages }}"
     state: present
 
 - block:
-    - name: ensure spamd group is present
-      group:
-        name: "{{ spamassassin_user }}"
-        state: present
 
-    - name: ensure spamd user is present
-      user:
-        name: "{{ spamassassin_user }}"
-        shell: /bin/false
-        home: "{{ spamassassin_home_dir }}"
-        groups: "{{ spamassassin_group }}"
-        append: yes
 
     - name: ensure spamassassin's directories are present
       file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
   register: id_cmd
   # rc=1 is OK, indicates that there is no spamd user
   failed_when: id_cmd.rc >= 2
+  changed_when: false
 
 - name: stop spamassassin
   service:
@@ -18,6 +19,7 @@
   register: killall_cmd
   # rc=1 is OK, indicates that there are no processes to be killed
   failed_when: killall_cmd.rc >= 2
+  changed_when: false
   when: id_cmd.rc == 0
 
 - name: ensure spamd group is present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
   when: id_cmd.rc == 0
 
 - name: Kill running processes for user spamd
-  shell: "killall -u {{ spamassassin_user }}"
+  shell: "pkill -u {{ spamassassin_user }}"
   register: killall_cmd
   # rc=1 is OK, indicates that there are no processes to be killed
   failed_when: killall_cmd.rc >= 2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
 - name: ensure spamd user is present
   user:
     name: "{{ spamassassin_user }}"
-    # Need to have a shell, otherwise updates in Debian fails
+    # Need to have a shell,otherwise updates in Debian fails
     shell: /bin/sh
     home: "{{ spamassassin_home_dir }}"
     groups: "{{ spamassassin_group }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
     name: spamassassin
     state: stopped
   failed_when: false
+  changed_when: false
   when: id_cmd.rc == 0
 
 - name: Kill running processes for user spamd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   service:
     name: spamassassin
     state: stopped
-  failed_when: false  
+  failed_when: false
   when: id_cmd.rc == 0
 
 - name: Kill running processes for user spamd


### PR DESCRIPTION
Have now rebased
Why this change:
- shell need to be a valid shell (at least on debian). Otherwise it will fail if using auto-update.
- allow the playbook to be rerun without manual uninstall first

