### PR TITLE
Make RBL timeout configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -294,7 +294,38 @@ spamassassin_additional_update_channels: []
 #     - allow zen.spamhaus.org
 #     - deny spamhaus.org mailspike.net spamcop.net
 spamassassin_dns_query_restrictions: []
-  
+
+# All DNS queries are made at the beginning of a check and we try to read the
+# results at the end. This value specifies the maximum period of time (in
+# seconds) to wait for a DNS query. If most of the DNS queries have succeeded
+# for a particular message, then SpamAssassin will not wait for the full period
+# to avoid wasting time on unresponsive server(s), but will shrink the timeout
+# according to a percentage of queries already completed. As the number of
+# queries remaining approaches 0, the timeout value will gradually approach a
+# t_min value, which is an optional second parameter and defaults to 0.2 * t.
+# If t is smaller than t_min, the initial timeout is set to t_min. Here is a
+# chart of queries remaining versus the timeout in seconds, for the default 15
+# second / 3 second timeout setting:
+#
+# queries left  100%  90%  80%  70%  60%  50%  40%  30%  20%  10%   0%
+# timeout        15   14.9 14.5 13.9 13.1 12.0 10.7  9.1  7.3  5.3  3
+#
+# For example, if 20 queries are made at the beginning of a message check
+# and 16 queries have returned (leaving 20%), the remaining 4 queries should
+# finish within 7.3 seconds since their query started or they will be timed
+# out. Note that timed out queries are only aborted when there is nothing
+# else left for SpamAssassin to do - long evaluation of other rules may
+# grant queries additional time.
+#
+# If a parameter 'zone' is specified (it must end with a letter, which
+# distinguishes it from other numeric parametrs), then the setting only
+# applies to DNS queries against the specified DNS domain (host, domain or
+# RBL (sub)zone). Matching is case-insensitive, the actual domain may be a
+# subdomain of the specified zone.
+#
+# rbl_timeout t [t_min] [zone] (default: 15 3)
+spamassassin_rbl_timeout: 15 3
+
 # Enable additional pyzor check
 spamassassin_pyzor_enabled: True
 

--- a/templates/spamassassin/local.cf.j2
+++ b/templates/spamassassin/local.cf.j2
@@ -404,7 +404,7 @@ dns_query_restriction {{ dns_query_restriction }}
 #
 # rbl_timeout t [t_min] [zone] (default: 15 3)
 
-rbl_timeout 25 5
+rbl_timeout {{ spamassassin_rbl_timeout }}
 
 #   Some shortcircuiting, if the plugin is enabled
 #


### PR DESCRIPTION
All DNS queries are made at the beginning of a check and we try to read the results at the end. This value specifies the maximum period of time (in seconds) to wait for a DNS query. If most of the DNS queries have succeeded for a particular message, then SpamAssassin will not wait for the full period to avoid wasting time on unresponsive server(s), but will shrink the timeout according to a percentage of queries already completed. As the number of queries remaining approaches 0, the timeout value will gradually approach a t_min value, which is an optional second parameter and defaults to 0.2 * t.  If t is smaller than t_min, the initial timeout is set to t_min. Here is a chart of queries remaining versus the timeout in seconds, for the default 15 second / 3 second timeout setting:

queries left  100%  90%  80%  70%  60%  50%  40%  30%  20%  10%   0%
timeout        15   14.9 14.5 13.9 13.1 12.0 10.7  9.1  7.3  5.3  3

For example, if 20 queries are made at the beginning of a message check and 16 queries have returned (leaving 20%), the remaining 4 queries should finish within 7.3 seconds since their query started or they will be timed out. Note that timed out queries are only aborted when there is nothing else left for SpamAssassin to do - long evaluation of other rules may grant queries additional time.

If a parameter 'zone' is specified (it must end with a letter, which distinguishes it from other numeric parametrs), then the setting only applies to DNS queries against the specified DNS domain (host, domain or RBL (sub)zone). Matching is case-insensitive, the actual domain may be a subdomain of the specified zone.

rbl_timeout t [t_min] [zone] (default: 15 3)